### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish-packages.yml
+++ b/.github/workflows/npm-publish-packages.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
 name: Node.js Package
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/rssaini01/openseadragon-konva-layer/security/code-scanning/2](https://github.com/rssaini01/openseadragon-konva-layer/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block in the workflow to grant the least privilege required by the workflow. For most npm publish workflows, the only required GitHub API permission is `contents: read` (for actions such as `actions/checkout`), since npm authentication uses a separate token (`NPM_TOKEN`). No write permissions to the repository are necessary for this workflow.

You can add the following at the top-level of the workflow (i.e., after the `name:` line, before `on:`). This will apply to all jobs in the workflow:
```yaml
permissions:
  contents: read
```
No extra methods, imports, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
